### PR TITLE
Prepare for v1.0.6 release

### DIFF
--- a/custom_components/span_panel/manifest.json
+++ b/custom_components/span_panel/manifest.json
@@ -7,7 +7,7 @@
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/SpanPanel/span/issues",
   "requirements": [],
-  "version": "1.0.5",
+  "version": "1.0.6",
   "zeroconf": [
     {
       "type": "_span._tcp.local."

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "span"
-version = "1.0.5"
+version = "1.0.6"
 description = "Span Panel Custom Integration for Home Assistant"
 authors = ["SpanPanel"]
 license = "MIT"


### PR DESCRIPTION
I wanted to make sure we had a release after moving to repo, so that all the links are fully updated, the README is well clarified, and so that the HACS maintainers can't claim we didn't have a release with passing actions.