### PR TITLE
Sim serial uniquiness

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### 🔧 Technical Improvements
 
 - **Circuit Naming Logic**: Fixed logic for circuit naming patterns to ensure proper entity ID generation and panel prefixes (fresh installs only)
-- **Panel Friendly Name Sync**: Fixed regression in panel circuit name synchronization. A new install will sync all friendly names once and anytime a user
-  changes the name in the mobile/SPAN App.
+- **Entity ID naming Choices**: Added the ability to change entity ID naming patterns in live panels
+- **Panel Friendly Name Sync**: Fixed regression in panel circuit name synchronization. A new install will sync all friendly names once on the first refresh and
+  anytime a user changes a name in the SPAN App changes the name in the mobile/SPAN App.
 - **API Optimization**: Removed unnecessary signal updates to improve performance and reduce overhead
-- **API Dependencies**: Updated span-panel-api to version 1.1.13 for improved stability
+- **API Dependencies**: Updated span-panel-api OpenAPI package to version 1.1.13 to remove the cache
 - **Resolve Cache Config Entry**: Fixed an issue where a config entry tried to set up a cache window in the underlying OpenAPI library that was invalid
 
 ## [1.2.5] - 2025-09-XX

--- a/custom_components/span_panel/helpers.py
+++ b/custom_components/span_panel/helpers.py
@@ -7,6 +7,7 @@ import re
 from typing import TYPE_CHECKING, Any
 
 from homeassistant.components.persistent_notification import async_create
+from homeassistant.const import CONF_HOST
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers import entity_registry as er
 from homeassistant.util import slugify
@@ -689,6 +690,7 @@ def generate_unique_simulator_serial_number(hass: HomeAssistant) -> str:
         Unique serial number in format sim-nnn (e.g., sim-001, sim-002, etc.)
 
     """
+
     # Get all existing span panel config entries
     existing_entries = hass.config_entries.async_entries(DOMAIN)
 
@@ -696,10 +698,16 @@ def generate_unique_simulator_serial_number(hass: HomeAssistant) -> str:
     existing_serials = set()
     for entry in existing_entries:
         if entry.data.get("simulation_mode", False):
-            # Check if the entry has a serial number in the data
+            # Check both simulator_serial_number and CONF_HOST fields
+            # simulator_serial_number is the newer field
             serial = entry.data.get("simulator_serial_number")
             if serial and serial.startswith("sim-"):
                 existing_serials.add(serial)
+
+            # CONF_HOST may contain the serial for existing simulator configurations
+            host_serial = entry.data.get(CONF_HOST)
+            if host_serial and host_serial.startswith("sim-"):
+                existing_serials.add(host_serial)
 
     # Find the next available number
     counter = 1


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Improve simulator serial generation to avoid collisions and update 1.2.6 changelog with naming options and dependency notes.
> 
> - **Helpers (`custom_components/span_panel/helpers.py`)**:
>   - Simulator serial generation now checks both `data.simulator_serial_number` and `CONF_HOST` for existing `sim-*` entries to ensure uniqueness.
> - **Changelog (`CHANGELOG.md`)**:
>   - Add entity ID naming choices for live panels.
>   - Clarify panel friendly name sync behavior on first refresh and subsequent app changes.
>   - Update API dependency note to OpenAPI 1.1.13 (cache removal).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ddd133f8361b66ab9bbbafbcffb5d9d57ddde30d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->