### PR TITLE
add panel net energy and net energy config options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,13 +9,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ### 🔧 Technical Improvements
 
-- **Circuit Naming Logic**: Fixed logic for circuit naming patterns to ensure proper entity ID generation and panel prefixes (fresh installs only)
-- **Entity ID naming Choices**: Added the ability to change entity ID naming patterns in live panels
+- **Panel Level Net Energy**: Add net energy sensors for main meter and feed-through (consumed - produced)
+- **Net Energy Config Options**: Added separate config options to enable/disable panel, circuit, leg-based net energy. Disabling circuit net energy can help
+  resource constrained installations since the sensors are not created or updated
+- **Circuit Naming Logic**: Fixed logic for circuit-naming patterns to ensure proper entity ID generation and panel prefixes (fresh installs only)
+- **Entity ID naming Choices**: Restored the ability to change entity ID naming patterns in live panels (circuit tab-based sensors only, not panel)
 - **Panel Friendly Name Sync**: Fixed regression in panel circuit name synchronization. A new install will sync all friendly names once on the first refresh and
   anytime a user changes a name in the SPAN App changes the name in the mobile/SPAN App.
 - **API Optimization**: Removed unnecessary signal updates to improve performance and reduce overhead
 - **API Dependencies**: Updated span-panel-api OpenAPI package to version 1.1.13 to remove the cache
-- **Resolve Cache Config Entry**: Fixed an issue where a config entry tried to set up a cache window in the underlying OpenAPI library that was invalid
+- **Resolve Cache Config Entry Defect**: Fixed an issue where a 1.2.5 config entry could attempt to set up a cache window in the underlying OpenAPI library that
+  was invalid
 
 ## [1.2.5] - 2025-09-XX
 

--- a/custom_components/span_panel/config_flow_utils/options.py
+++ b/custom_components/span_panel/config_flow_utils/options.py
@@ -23,6 +23,9 @@ from custom_components.span_panel.const import (
     DEFAULT_API_RETRY_BACKOFF_MULTIPLIER,
     DEFAULT_API_RETRY_TIMEOUT,
     DEFAULT_SCAN_INTERVAL,
+    ENABLE_CIRCUIT_NET_ENERGY_SENSORS,
+    ENABLE_PANEL_NET_ENERGY_SENSORS,
+    ENABLE_SOLAR_NET_ENERGY_SENSORS,
     ENTITY_NAMING_PATTERN,
     USE_CIRCUIT_NUMBERS,
     USE_DEVICE_PREFIX,
@@ -91,6 +94,9 @@ def build_general_options_schema(
         vol.Optional(INVERTER_LEG2, default=str(current_leg2)): selector(
             {"select": {"options": leg2_select_options, "mode": "dropdown"}}
         ),
+        vol.Optional(ENABLE_SOLAR_NET_ENERGY_SENSORS): bool,
+        vol.Optional(ENABLE_PANEL_NET_ENERGY_SENSORS): bool,
+        vol.Optional(ENABLE_CIRCUIT_NET_ENERGY_SENSORS): bool,
         vol.Optional(CONF_API_RETRIES): vol.All(int, vol.Range(min=0, max=10)),
         vol.Optional(CONF_API_RETRY_TIMEOUT): vol.All(
             vol.Coerce(float), vol.Range(min=0.1, max=10.0)
@@ -129,6 +135,15 @@ def get_general_options_defaults(
         # Defaults for selector values must be strings
         INVERTER_LEG1: str(current_leg1),
         INVERTER_LEG2: str(current_leg2),
+        ENABLE_PANEL_NET_ENERGY_SENSORS: config_entry.options.get(
+            ENABLE_PANEL_NET_ENERGY_SENSORS, True
+        ),
+        ENABLE_CIRCUIT_NET_ENERGY_SENSORS: config_entry.options.get(
+            ENABLE_CIRCUIT_NET_ENERGY_SENSORS, True
+        ),
+        ENABLE_SOLAR_NET_ENERGY_SENSORS: config_entry.options.get(
+            ENABLE_SOLAR_NET_ENERGY_SENSORS, True
+        ),
         CONF_API_RETRIES: config_entry.options.get(CONF_API_RETRIES, DEFAULT_API_RETRIES),
         CONF_API_RETRY_TIMEOUT: config_entry.options.get(
             CONF_API_RETRY_TIMEOUT, DEFAULT_API_RETRY_TIMEOUT

--- a/custom_components/span_panel/const.py
+++ b/custom_components/span_panel/const.py
@@ -84,6 +84,11 @@ PANEL_BACKUP = "PANEL_BACKUP"
 # Entity naming pattern options
 ENTITY_NAMING_PATTERN = "entity_naming_pattern"
 
+# Net energy sensor configuration
+ENABLE_PANEL_NET_ENERGY_SENSORS = "enable_panel_net_energy_sensors"
+ENABLE_CIRCUIT_NET_ENERGY_SENSORS = "enable_circuit_net_energy_sensors"
+ENABLE_SOLAR_NET_ENERGY_SENSORS = "enable_solar_net_energy_sensors"
+
 DEFAULT_SCAN_INTERVAL = timedelta(seconds=15)
 # API timeout and retry configuration
 API_TIMEOUT = 30  # Default timeout for normal operations

--- a/custom_components/span_panel/options.py
+++ b/custom_components/span_panel/options.py
@@ -13,6 +13,9 @@ from .const import (
     DEFAULT_API_RETRIES,
     DEFAULT_API_RETRY_BACKOFF_MULTIPLIER,
     DEFAULT_API_RETRY_TIMEOUT,
+    ENABLE_CIRCUIT_NET_ENERGY_SENSORS,
+    ENABLE_PANEL_NET_ENERGY_SENSORS,
+    ENABLE_SOLAR_NET_ENERGY_SENSORS,
 )
 
 INVERTER_ENABLE = "enable_solar_circuit"
@@ -40,6 +43,15 @@ class Options:
         self.energy_display_precision: int = entry.options.get(ENERGY_DISPLAY_PRECISION, 2)
         self.energy_reporting_grace_period: int = entry.options.get(
             ENERGY_REPORTING_GRACE_PERIOD, 15
+        )
+        self.enable_panel_net_energy_sensors: bool = entry.options.get(
+            ENABLE_PANEL_NET_ENERGY_SENSORS, True
+        )
+        self.enable_circuit_net_energy_sensors: bool = entry.options.get(
+            ENABLE_CIRCUIT_NET_ENERGY_SENSORS, True
+        )
+        self.enable_solar_net_energy_sensors: bool = entry.options.get(
+            ENABLE_SOLAR_NET_ENERGY_SENSORS, True
         )
 
         # API retry configuration options
@@ -73,6 +85,9 @@ class Options:
             POWER_DISPLAY_PRECISION: self.power_display_precision,
             ENERGY_DISPLAY_PRECISION: self.energy_display_precision,
             ENERGY_REPORTING_GRACE_PERIOD: self.energy_reporting_grace_period,
+            ENABLE_PANEL_NET_ENERGY_SENSORS: self.enable_panel_net_energy_sensors,
+            ENABLE_CIRCUIT_NET_ENERGY_SENSORS: self.enable_circuit_net_energy_sensors,
+            ENABLE_SOLAR_NET_ENERGY_SENSORS: self.enable_solar_net_energy_sensors,
             CONF_API_RETRIES: self.api_retries,
             CONF_API_RETRY_TIMEOUT: self.api_retry_timeout,
             CONF_API_RETRY_BACKOFF_MULTIPLIER: self.api_retry_backoff_multiplier,

--- a/custom_components/span_panel/sensor_definitions.py
+++ b/custom_components/span_panel/sensor_definitions.py
@@ -206,6 +206,8 @@ PANEL_ENERGY_SENSORS: tuple[
     SpanPanelDataSensorEntityDescription,
     SpanPanelDataSensorEntityDescription,
     SpanPanelDataSensorEntityDescription,
+    SpanPanelDataSensorEntityDescription,
+    SpanPanelDataSensorEntityDescription,
 ] = (
     SpanPanelDataSensorEntityDescription(
         key="mainMeterEnergyProducedWh",
@@ -242,6 +244,26 @@ PANEL_ENERGY_SENSORS: tuple[
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
         value_fn=lambda panel_data: panel_data.feedthrough_energy_consumed,
+    ),
+    SpanPanelDataSensorEntityDescription(
+        key="mainMeterNetEnergyWh",
+        name="Main Meter Net Energy",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        state_class=SensorStateClass.TOTAL,
+        suggested_display_precision=2,
+        device_class=SensorDeviceClass.ENERGY,
+        value_fn=lambda panel_data: (panel_data.main_meter_energy_consumed or 0)
+        - (panel_data.main_meter_energy_produced or 0),
+    ),
+    SpanPanelDataSensorEntityDescription(
+        key="feedthroughNetEnergyWh",
+        name="Feed Through Net Energy",
+        native_unit_of_measurement=UnitOfEnergy.WATT_HOUR,
+        state_class=SensorStateClass.TOTAL,
+        suggested_display_precision=2,
+        device_class=SensorDeviceClass.ENERGY,
+        value_fn=lambda panel_data: (panel_data.feedthrough_energy_consumed or 0)
+        - (panel_data.feedthrough_energy_produced or 0),
     ),
 )
 
@@ -292,7 +314,7 @@ CIRCUIT_SENSORS: tuple[
         state_class=SensorStateClass.TOTAL,
         suggested_display_precision=2,
         device_class=SensorDeviceClass.ENERGY,
-        value_fn=lambda circuit: (circuit.produced_energy or 0) - (circuit.consumed_energy or 0),
+        value_fn=lambda circuit: (circuit.consumed_energy or 0) - (circuit.produced_energy or 0),
         entity_registry_enabled_default=True,
         entity_registry_visible_default=True,
     ),

--- a/custom_components/span_panel/sensors/factory.py
+++ b/custom_components/span_panel/sensors/factory.py
@@ -65,20 +65,12 @@ def create_panel_sensors(
     # Add panel energy sensors (replacing synthetic ones)
     # Filter out net energy sensors if disabled
     panel_net_energy_enabled = config_entry.options.get(ENABLE_PANEL_NET_ENERGY_SENSORS, True)
-    _LOGGER.debug("PANEL_NET_ENERGY_DEBUG: panel_net_energy_enabled=%s", panel_net_energy_enabled)
 
     for description in PANEL_ENERGY_SENSORS:
         # Skip net energy sensors if disabled
         is_net_energy_sensor = "net_energy" in description.key or "NetEnergy" in description.key
-        _LOGGER.debug(
-            "PANEL_NET_ENERGY_DEBUG: sensor_key=%s, is_net_energy=%s, enabled=%s",
-            description.key,
-            is_net_energy_sensor,
-            panel_net_energy_enabled,
-        )
 
         if not panel_net_energy_enabled and is_net_energy_sensor:
-            _LOGGER.debug("PANEL_NET_ENERGY_DEBUG: Skipping net energy sensor %s", description.key)
             continue
         entities.append(SpanPanelEnergySensor(coordinator, description, span_panel))
 
@@ -99,30 +91,14 @@ def create_circuit_sensors(
     named_circuits = [cid for cid in span_panel.circuits if not cid.startswith("unmapped_tab_")]
     circuit_net_energy_enabled = config_entry.options.get(ENABLE_CIRCUIT_NET_ENERGY_SENSORS, True)
 
-    _LOGGER.debug(
-        "CIRCUIT_NET_ENERGY_DEBUG: circuit_net_energy_enabled=%s, config_entry.options=%s",
-        circuit_net_energy_enabled,
-        config_entry.options,
-    )
-
     for circuit_id in named_circuits:
         for circuit_description in CIRCUIT_SENSORS:
             # Skip net energy sensors if disabled
             is_net_energy_sensor = (
                 "net_energy" in circuit_description.key or "energy_net" in circuit_description.key
             )
-            _LOGGER.debug(
-                "CIRCUIT_NET_ENERGY_DEBUG: sensor_key=%s, is_net_energy=%s, enabled=%s",
-                circuit_description.key,
-                is_net_energy_sensor,
-                circuit_net_energy_enabled,
-            )
 
             if not circuit_net_energy_enabled and is_net_energy_sensor:
-                _LOGGER.debug(
-                    "CIRCUIT_NET_ENERGY_DEBUG: Skipping net energy sensor %s",
-                    circuit_description.key,
-                )
                 continue
 
             if circuit_description.key == "circuit_power":

--- a/custom_components/span_panel/strings.json
+++ b/custom_components/span_panel/strings.json
@@ -102,6 +102,9 @@
           "enable_solar_circuit": "Enable Solar Inverter Sensors",
           "leg1": "Solar Leg 1 (must be unmapped tab on opposite phase from Leg 2)",
           "leg2": "Solar Leg 2 (must be unmapped tab on opposite phase from Leg 1)",
+          "enable_panel_net_energy_sensors": "Panel Net Energy",
+          "enable_circuit_net_energy_sensors": "Circuit Net Energy",
+          "enable_solar_net_energy_sensors": "Solar Net Energy",
           "api_retries": "API Retries (0-10)",
           "api_retry_timeout": "API Retry Timeout (seconds)",
           "api_retry_backoff_multiplier": "API Retry Backoff Multiplier"
@@ -109,7 +112,10 @@
         "data_description": {
           "enable_solar_circuit": "Enable synthetic sensors for solar inverter monitoring. Requires selection of two unmapped tabs on opposite electrical phases.",
           "leg1": "Select the first solar leg from available unmapped tabs. This tab must be on the opposite electrical phase from Leg 2 for proper 240V measurement.",
-          "leg2": "Select the second solar leg from available unmapped tabs. This tab must be on the opposite electrical phase from Leg 1 for proper 240V measurement."
+          "leg2": "Select the second solar leg from available unmapped tabs. This tab must be on the opposite electrical phase from Leg 1 for proper 240V measurement.",
+          "enable_panel_net_energy_sensors": "Create net energy sensors for panel-level energy flows (main meter and feed-through). Shows true energy balance accounting for bidirectional flows.",
+          "enable_circuit_net_energy_sensors": "Create net energy sensors for individual circuits. Shows true energy consumption accounting for reactive power and regenerative flows.",
+          "enable_solar_net_energy_sensors": "Create net energy sensors for solar generation (only available when solar is configured). Shows net solar production accounting for any consumption on solar circuits."
         }
       },
       "entity_naming_options": {

--- a/custom_components/span_panel/translations/en.json
+++ b/custom_components/span_panel/translations/en.json
@@ -105,12 +105,18 @@
           "api_retry_timeout": "API Retry Timeout (seconds)",
           "api_retry_backoff_multiplier": "API Retry Backoff Multiplier",
           "energy_reporting_grace_period": "Energy Sensor Grace Period (minutes)",
-          "legacy_upgrade_to_friendly": "Add Device Name Prefix to Entity ID's"
+          "legacy_upgrade_to_friendly": "Add Device Name Prefix to Entity ID's",
+          "enable_panel_net_energy_sensors": "Panel Net Energy",
+          "enable_circuit_net_energy_sensors": "Circuit Net Energy",
+          "enable_solar_net_energy_sensors": "Solar Net Energy"
         },
         "data_description": {
           "enable_solar_circuit": "Enable synthetic sensors for solar inverter monitoring. Requires selection of two unmapped tabs on opposite electrical phases.",
           "energy_reporting_grace_period": "How long energy sensors maintain their last known value when the panel becomes unavailable (0-60 minutes). Helps preserve energy statistics integrity during brief outages. Default: 15 minutes.",
-          "legacy_upgrade_to_friendly": "Warning: This irreversible operation will change your circuit entity IDs allowing support for more than one panel"
+          "legacy_upgrade_to_friendly": "Warning: This irreversible operation will change your circuit entity IDs allowing support for more than one panel",
+          "enable_panel_net_energy_sensors": "Create net energy sensors for panel-level energy flows (main meter and feed-through). Shows true energy balance accounting for bidirectional flows.",
+          "enable_circuit_net_energy_sensors": "Create net energy sensors for individual circuits. Shows true energy consumption accounting for reactive power and regenerative flows.",
+          "enable_solar_net_energy_sensors": "Create net energy sensors for solar generation (only available when solar is configured). Shows net solar production accounting for any consumption on solar circuits."
         }
       },
       "entity_naming_options": {

--- a/custom_components/span_panel/translations/es.json
+++ b/custom_components/span_panel/translations/es.json
@@ -100,12 +100,18 @@
           "api_retry_timeout": "Tiempo de espera de reintento de API (segundos)",
           "api_retry_backoff_multiplier": "Multiplicador de retraso de reintento de API",
           "energy_reporting_grace_period": "Período de Gracia del Sensor de Energía (minutos)",
-          "legacy_upgrade_to_friendly": "Add Device Name Prefix to Entity ID's"
+          "legacy_upgrade_to_friendly": "Add Device Name Prefix to Entity ID's",
+          "enable_panel_net_energy_sensors": "Energía Neta del Panel",
+          "enable_circuit_net_energy_sensors": "Energía Neta del Circuito",
+          "enable_solar_net_energy_sensors": "Energía Neta Solar"
         },
         "data_description": {
           "enable_solar_circuit": "Habilitar sensores sintéticos para monitoreo de inversor solar. Requiere selección de dos pestañas no mapeadas en fases eléctricas opuestas.",
           "energy_reporting_grace_period": "Cuánto tiempo los sensores de energía mantienen su último valor conocido cuando el panel no está disponible (0-60 minutos). Ayuda a preservar la integridad de las estadísticas de energía durante cortes breves. Predeterminado: 15 minutos.",
-          "legacy_upgrade_to_friendly": "Warning: This irreversible operation will change your circuit entity IDs allowing support for more than one panel"
+          "legacy_upgrade_to_friendly": "Warning: This irreversible operation will change your circuit entity IDs allowing support for more than one panel",
+          "enable_panel_net_energy_sensors": "Crear sensores de energía neta para flujos de energía a nivel de panel (medidor principal y derivación). Muestra el verdadero balance de energía contabilizando flujos bidireccionales.",
+          "enable_circuit_net_energy_sensors": "Crear sensores de energía neta para circuitos individuales. Muestra el verdadero consumo de energía contabilizando potencia reactiva y flujos regenerativos.",
+          "enable_solar_net_energy_sensors": "Crear sensores de energía neta para generación solar. Muestra la producción solar neta contabilizando cualquier consumo en circuitos solares."
         }
       },
       "entity_naming_options": {

--- a/custom_components/span_panel/translations/fr.json
+++ b/custom_components/span_panel/translations/fr.json
@@ -100,12 +100,18 @@
           "api_retry_timeout": "Délai de tentative API (secondes)",
           "api_retry_backoff_multiplier": "Multiplicateur de délai de tentative API",
           "energy_reporting_grace_period": "Période de grâce du capteur d'énergie (minutes)",
-          "legacy_upgrade_to_friendly": "Add Device Name Prefix to Entity ID's"
+          "legacy_upgrade_to_friendly": "Add Device Name Prefix to Entity ID's",
+          "enable_panel_net_energy_sensors": "Énergie Nette du Panneau",
+          "enable_circuit_net_energy_sensors": "Énergie Nette du Circuit",
+          "enable_solar_net_energy_sensors": "Énergie Nette Solaire"
         },
         "data_description": {
           "enable_solar_circuit": "Activer les capteurs synthétiques pour la surveillance de l'onduleur solaire. Nécessite la sélection de deux onglets non mappés sur des phases électriques opposées.",
           "energy_reporting_grace_period": "Combien de temps les capteurs d'énergie maintiennent leur dernière valeur connue lorsque le panneau devient indisponible (0-60 minutes). Aide à préserver l'intégrité des statistiques d'énergie pendant les pannes brèves. Par défaut : 15 minutes.",
-          "legacy_upgrade_to_friendly": "Warning: This irreversible operation will change your circuit entity IDs allowing support for more than one panel"
+          "legacy_upgrade_to_friendly": "Warning: This irreversible operation will change your circuit entity IDs allowing support for more than one panel",
+          "enable_panel_net_energy_sensors": "Créer des capteurs d'énergie nette pour les flux d'énergie au niveau du panneau (compteur principal et dérivation). Affiche le vrai bilan énergétique en tenant compte des flux bidirectionnels.",
+          "enable_circuit_net_energy_sensors": "Créer des capteurs d'énergie nette pour les circuits individuels. Affiche la vraie consommation d'énergie en tenant compte de la puissance réactive et des flux régénératifs.",
+          "enable_solar_net_energy_sensors": "Créer des capteurs d'énergie nette pour la génération solaire. Affiche la production solaire nette en tenant compte de toute consommation sur les circuits solaires."
         }
       },
       "entity_naming_options": {

--- a/custom_components/span_panel/translations/ja.json
+++ b/custom_components/span_panel/translations/ja.json
@@ -100,12 +100,18 @@
           "api_retry_timeout": "APIリトライタイムアウト (秒)",
           "api_retry_backoff_multiplier": "APIリトライバックオフ倍率",
           "energy_reporting_grace_period": "エネルギーセンサー猶予期間 (分)",
-          "legacy_upgrade_to_friendly": "Add Device Name Prefix to Entity ID's"
+          "legacy_upgrade_to_friendly": "Add Device Name Prefix to Entity ID's",
+          "enable_panel_net_energy_sensors": "パネル正味エネルギー",
+          "enable_circuit_net_energy_sensors": "回路正味エネルギー",
+          "enable_solar_net_energy_sensors": "ソーラー正味エネルギー"
         },
         "data_description": {
           "enable_solar_circuit": "ソーラーインバーター監視用の合成センサーを有効にします。反対の電気相の2つの未マップタブの選択が必要です。",
           "energy_reporting_grace_period": "パネルが利用できなくなったときにエネルギーセンサーが最後の既知の値を維持する時間（0-60分）。短時間の停電中にエネルギー統計の整合性を維持するのに役立ちます。デフォルト：15分。",
-          "legacy_upgrade_to_friendly": "Warning: This irreversible operation will change your circuit entity IDs allowing support for more than one panel"
+          "legacy_upgrade_to_friendly": "Warning: This irreversible operation will change your circuit entity IDs allowing support for more than one panel",
+          "enable_panel_net_energy_sensors": "パネルレベルエネルギー流れ（メインメーターとフィードスルー）の正味エネルギーセンサーを作成します。双方向流れを考慮した真のエネルギー収支を表示します。",
+          "enable_circuit_net_energy_sensors": "個別回路の正味エネルギーセンサーを作成します。無効電力と回生流れを考慮した真のエネルギー消費を表示します。",
+          "enable_solar_net_energy_sensors": "ソーラー発電の正味エネルギーセンサーを作成します。ソーラー回路での消費を考慮した正味ソーラー生産量を表示します。"
         }
       },
       "entity_naming_options": {

--- a/custom_components/span_panel/translations/pt.json
+++ b/custom_components/span_panel/translations/pt.json
@@ -100,12 +100,18 @@
           "api_retry_timeout": "Tempo limite de tentativa de API (segundos)",
           "api_retry_backoff_multiplier": "Multiplicador de atraso de tentativa de API",
           "energy_reporting_grace_period": "Período de Graça do Sensor de Energia (minutos)",
-          "legacy_upgrade_to_friendly": "Add Device Name Prefix to Entity ID's"
+          "legacy_upgrade_to_friendly": "Add Device Name Prefix to Entity ID's",
+          "enable_panel_net_energy_sensors": "Energia Líquida do Painel",
+          "enable_circuit_net_energy_sensors": "Energia Líquida do Circuito",
+          "enable_solar_net_energy_sensors": "Energia Líquida Solar"
         },
         "data_description": {
           "enable_solar_circuit": "Ativar sensores sintéticos para monitoramento do inversor solar. Requer seleção de duas abas não mapeadas em fases elétricas opostas.",
           "energy_reporting_grace_period": "Quanto tempo os sensores de energia mantêm seu último valor conhecido quando o painel fica indisponível (0-60 minutos). Ajuda a preservar a integridade das estatísticas de energia durante interrupções breves. Padrão: 15 minutos.",
-          "legacy_upgrade_to_friendly": "Warning: This irreversible operation will change your circuit entity IDs allowing support for more than one panel"
+          "legacy_upgrade_to_friendly": "Warning: This irreversible operation will change your circuit entity IDs allowing support for more than one panel",
+          "enable_panel_net_energy_sensors": "Criar sensores de energia líquida para fluxos de energia no nível do painel (medidor principal e derivação). Mostra o verdadeiro balanço energético contabilizando fluxos bidirecionais.",
+          "enable_circuit_net_energy_sensors": "Criar sensores de energia líquida para circuitos individuais. Mostra o verdadeiro consumo de energia contabilizando potência reativa e fluxos regenerativos.",
+          "enable_solar_net_energy_sensors": "Criar sensores de energia líquida para geração solar. Mostra a produção solar líquida contabilizando qualquer consumo em circuitos solares."
         }
       },
       "entity_naming_options": {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds panel-level net energy sensors and config flags to enable/disable net energy sensors for panel, circuit, and solar; updates factories and flips circuit net energy to consumed − produced.
> 
> - **Sensors**:
>   - **Panel Energy**: Add `mainMeterNetEnergyWh` and `feedthroughNetEnergyWh` (computed as `consumed - produced`) in `custom_components/span_panel/sensor_definitions.py`.
>   - **Circuit Net Energy**: Change `circuit_energy_net` formula to `consumed - produced`.
> - **Configuration/Factory**:
>   - New options `enable_panel_net_energy_sensors`, `enable_circuit_net_energy_sensors`, `enable_solar_net_energy_sensors` defined in `custom_components/span_panel/const.py`, surfaced in options schema/defaults (`config_flow_utils/options.py`, `options.py`).
>   - Sensor creation filters net-energy entities based on these flags; `create_panel_sensors`, `create_circuit_sensors`, and `create_solar_sensors` updated to accept `ConfigEntry` and skip net-energy sensors when disabled in `custom_components/span_panel/sensors/factory.py`.
> - **UI/Translations**:
>   - Strings and translations updated to expose new toggles in `strings.json` and `translations/*.json`.
> - **Changelog**:
>   - Notes added for panel/circuit/solar net energy sensors and related config options; wording tweaks for naming logic and cache defect.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4f2054676746980ca7c04efb38af92a93348d98a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->