### PR TITLE
fix don't call simulation listener, not in sim mode

### DIFF
--- a/custom_components/span_panel/__init__.py
+++ b/custom_components/span_panel/__init__.py
@@ -406,15 +406,21 @@ async def update_listener(hass: HomeAssistant, entry: ConfigEntry) -> None:
                         "Found existing SpanPanel API instance, updating simulation parameters"
                     )
 
-                    # Update simulation offline mode - this should start the offline timer
-                    # from "now"
-                    # The simulation_start_time is separate and used for the simulated time of day
-                    _LOGGER.info(
-                        "Calling span_panel.api.set_simulation_offline_mode(%s)",
-                        simulation_offline_minutes,
-                    )
-                    span_panel.api.set_simulation_offline_mode(simulation_offline_minutes)
-                    _LOGGER.info("Successfully called set_simulation_offline_mode")
+                    # Only update simulation offline mode if the API is actually in simulation mode
+                    if span_panel.api.simulation_mode:
+                        # Update simulation offline mode - this should start the offline timer
+                        # from "now"
+                        # The simulation_start_time is separate and used for the simulated time of day
+                        _LOGGER.info(
+                            "Calling span_panel.api.set_simulation_offline_mode(%s)",
+                            simulation_offline_minutes,
+                        )
+                        span_panel.api.set_simulation_offline_mode(simulation_offline_minutes)
+                        _LOGGER.info("Successfully called set_simulation_offline_mode")
+                    else:
+                        _LOGGER.debug(
+                            "Skipping simulation offline mode update - API not in simulation mode"
+                        )
                 else:
                     _LOGGER.warning("SpanPanel API instance not found in coordinator")
             else:


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Gate `set_simulation_offline_mode` so it runs only if `api.simulation_mode` is true; otherwise skip and log debug.
> 
> - **Span Panel integration**:
>   - **Update listener**: Conditionally call `span_panel.api.set_simulation_offline_mode(simulation_offline_minutes)` only when `span_panel.api.simulation_mode` is true.
>     - Adds debug log when skipping update because API is not in simulation mode.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6de0d190912060945d4f93dbfff3b8dc642c8f74. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->