### PR TITLE
bump span-panel-api to 2.6.4 and start 2.0.8 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2.0.8] - 5/2026
+
+### Fixed
+
+- **Integration reconnects automatically after a panel firmware upgrade** — previously, if the panel renewed its security certificate (for example during a
+  firmware update), the integration could get stuck offline and require a manual reload from the Devices & Services page. It now recovers on its own.
+- **Non-default panel ports now connect correctly** — panels configured to use a port other than the default are reached on the right port at startup.
+
 ## [2.0.7] - 5/2026
 
 ### Fixed

--- a/custom_components/span_panel/manifest.json
+++ b/custom_components/span_panel/manifest.json
@@ -24,7 +24,7 @@
   "requirements": [
     "span-panel-api==2.6.4"
   ],
-  "version": "2.0.7",
+  "version": "2.0.8",
   "zeroconf": [
     {
       "type": "_span._tcp.local."

--- a/custom_components/span_panel/manifest.json
+++ b/custom_components/span_panel/manifest.json
@@ -22,7 +22,7 @@
   ],
   "quality_scale": "gold",
   "requirements": [
-    "span-panel-api==2.6.2"
+    "span-panel-api==2.6.4"
   ],
   "version": "2.0.7",
   "zeroconf": [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 requires-python = ">=3.14.3,<3.15"
 dependencies = [
     "homeassistant==2026.4.4",
-    "span-panel-api==2.6.2",
+    "span-panel-api==2.6.4",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -2407,7 +2407,7 @@ dev = [
 
 [[package]]
 name = "span-panel-api"
-version = "2.6.2"
+version = "2.6.4"
 source = { editable = "../span-panel-api" }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Picks up MQTT reconnect self-healing (paho client rebuild + CA refetch so firmware-driven certificate rotations no longer wedge the integration) and the 2.6.3 fix that threads the configured panel port through the client factory.